### PR TITLE
Support user-provided end-of-line characters (#1242)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Install local tools

--- a/.github/workflows/myget.yml
+++ b/.github/workflows/myget.yml
@@ -24,7 +24,7 @@ jobs:
       run: echo Build number is $BUILD_NUMBER
     - uses: actions/checkout@v2
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Install local tools

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,15 @@
+### 4.3.0-alpha-005 - 11/2020
+
+* Support user-provided end-of-line characters. [#1231](https://github.com/fsprojects/fantomas/issues/1231)
+* Fix multiline yield bang in list should be further indented. [#1254](https://github.com/fsprojects/fantomas/issues/1254)
+* Fix Or pipe in destructured record should not be splitted. [#1252](https://github.com/fsprojects/fantomas/issues/1252)
+* Fix Swap order of private and inline. [#1250](https://github.com/fsprojects/fantomas/issues/1250)
+* Fix Comment is lost in enum. [#1247](https://github.com/fsprojects/fantomas/issues/1247)
+* Fix Nested if/else/then in short mode. [#1243](https://github.com/fsprojects/fantomas/issues/1243)
+* Fix Something doesn't add up in fix for 303. [#1093](https://github.com/fsprojects/fantomas/issues/1093)
+
 ### 4.3.0-alpha-004 - 11/2020
+
 * Update to FCS 38. [#1240](https://github.com/fsprojects/fantomas/pull/1240)
 
 ### 4.3.0-alpha-003 - 11/2020

--- a/src/Fantomas.CoreGlobalTool.Tests/ConfigTests.fs
+++ b/src/Fantomas.CoreGlobalTool.Tests/ConfigTests.fs
@@ -1,5 +1,6 @@
 module Fantomas.CoreGlobalTool.Tests.ConfigTests
 
+open Fantomas
 open NUnit.Framework
 open FsUnit
 open Fantomas.CoreGlobalTool.Tests.TestHelpers
@@ -30,3 +31,49 @@ indent_size=2
     |> should equal """let a = // foo
   9
 """
+
+[<Test>]
+let ``end_of_line=cr should throw an exception`` () =
+    use fileFixture =
+        new TemporaryFileCodeSample("let a = 9\n")
+
+    use configFixture =
+        new ConfigurationFile("""
+[*.fs]
+end_of_line=cr
+"""                            )
+
+    let exitCode, output = runFantomasTool fileFixture.Filename
+    exitCode |> should equal 1
+    StringAssert.Contains("Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'", output)
+
+let valid_eol_settings = [ "lf"; "crlf" ]
+
+[<TestCaseSource("valid_eol_settings")>]
+let ``uses end_of_line setting to write user newlines`` setting =
+    let newline =
+        (FormatConfig.EndOfLineStyle.OfConfigString setting)
+            .Value.NewLineString
+
+    let sampleCode nln =
+        sprintf "let a = 9%s%slet b = 7%s" nln nln nln
+
+    use fileFixture =
+        new TemporaryFileCodeSample(sampleCode "\n")
+
+    use configFixture =
+        new ConfigurationFile(sprintf """
+[*.fs]
+end_of_line = %s
+"""                            setting)
+
+    let (exitCode, _) = runFantomasTool fileFixture.Filename
+
+    exitCode |> should equal 0
+
+    let result =
+        System.IO.File.ReadAllText(fileFixture.Filename)
+
+    let expected = sampleCode newline
+
+    result |> should equal expected

--- a/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
+++ b/src/Fantomas.CoreGlobalTool.Tests/Fantomas.CoreGlobalTool.Tests.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <Version>4.3.0-alpha-004</Version>
+    <Version>4.3.0-alpha-005</Version>
     <NoWarn>FS0988</NoWarn>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
+++ b/src/Fantomas.CoreGlobalTool/Fantomas.CoreGlobalTool.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <ToolCommandName>fantomas</ToolCommandName>
     <PackAsTool>True</PackAsTool>
-    <Version>4.3.0-alpha-004</Version>
+    <Version>4.3.0-alpha-005</Version>
     <AssemblyName>fantomas-tool</AssemblyName>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Fantomas.Extras/EditorConfig.fs
+++ b/src/Fantomas.Extras/EditorConfig.fs
@@ -13,7 +13,10 @@ module Reflection =
         let values = FSharpValue.GetRecordFields x
         Seq.zip names values |> Seq.toArray
 
-let supportedProperties = [ "max_line_length"; "indent_size" ]
+let supportedProperties =
+    [ "max_line_length"
+      "indent_size"
+      "end_of_line" ]
 
 let private toEditorConfigName value =
     value
@@ -36,6 +39,8 @@ let private (|Number|_|) d =
 let private (|MultilineFormatterType|_|) mft =
     MultilineFormatterType.OfConfigString mft
 
+let private (|EndOfLineStyle|_|) eol = EndOfLineStyle.OfConfigString eol
+
 let private (|Boolean|_|) b =
     if b = "true" then Some(box true)
     elif b = "false" then Some(box false)
@@ -48,6 +53,7 @@ let private parseOptionsFromEditorConfig (editorConfig: EditorConfig.Core.FileCo
         | true, Number n -> n
         | true, Boolean b -> b
         | true, MultilineFormatterType mft -> mft
+        | true, EndOfLineStyle eol -> box eol
         | _ -> dv)
     |> fun newValues ->
         let formatConfigType = FormatConfig.Default.GetType()

--- a/src/Fantomas.Extras/Fantomas.Extras.fsproj
+++ b/src/Fantomas.Extras/Fantomas.Extras.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.3.0-alpha-004</Version>
+    <Version>4.3.0-alpha-005</Version>
     <Description>Utility package for Fantomas</Description>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Fantomas.Tests/ContextTests.fs
+++ b/src/Fantomas.Tests/ContextTests.fs
@@ -11,7 +11,7 @@ open Fantomas
 let ``sepSpace should not add an additional space if the line ends with a space`` () =
     let expr = !- "let a = " +> sepSpace
     let result = dump (expr Context.Default)
-    result |> should equal "let a = "
+    result |> should equal "let a ="
 
 [<Test>]
 let ``sepColon should not add a space when nothing proceeds it`` () =
@@ -54,7 +54,7 @@ let ``sepColon should not add a space when space proceeds it`` () =
 
     let ctx = { Context.Default with Config = config }
     let result = dump (expr ctx)
-    result |> should equal "let a : "
+    result |> should equal "let a :"
 
 [<Test>]
 let ``don't add space before block comment`` () =
@@ -79,7 +79,7 @@ Long comment
 
 Long comment
 
-*) """
+*)"""
 
 [<Test>]
 let ``nested exceedsMultiline expression should bubble up to parent check`` () =

--- a/src/Fantomas.Tests/Fantomas.Tests.fsproj
+++ b/src/Fantomas.Tests/Fantomas.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0-alpha-004</Version>
+    <Version>4.3.0-alpha-005</Version>
     <NoWarn>FS0988</NoWarn>
     <TargetFramework>net5.0</TargetFramework>
     <WarningsAsErrors>FS0025</WarningsAsErrors>

--- a/src/Fantomas.Tests/TestHelpers.fs
+++ b/src/Fantomas.Tests/TestHelpers.fs
@@ -98,7 +98,6 @@ let formatSourceStringWithDefines defines (s: string) config =
             return CodeFormatterImpl.formatWith ast defines hashTokens formatContext config
         }
         |> Async.RunSynchronously
-        |> CodeFormatterImpl.addNewlineIfNeeded
 
     // merge with itself to make #if go on beginning of line
     String.merge result result

--- a/src/Fantomas.Tests/TokenParserBoolExprTests.fs
+++ b/src/Fantomas.Tests/TokenParserBoolExprTests.fs
@@ -279,7 +279,7 @@ let ``Hash ifs source format property`` () =
              ==> lazy
                  (let source = boolExprsToSource es
                   let result = formatSourceString false source config
-                  result |> should equal source)))
+                  if String.isNotNullOrEmpty result then result |> should equal source)))
 
 [<Test>]
 let ``get define exprs from unit test with defines in triple quote string`` () =

--- a/src/Fantomas/CodeFormatterImpl.fs
+++ b/src/Fantomas/CodeFormatterImpl.fs
@@ -382,7 +382,7 @@ let formatWith ast defines hashTokens formatContext config =
         |> Dbg.tee (fun ctx -> printfn "%A" ctx.WriterEvents)
         |> Context.dump
 
-    formattedSourceCode |> String.removeTrailingSpaces
+    formattedSourceCode
 
 let format (checker: FSharpChecker) (parsingOptions: FSharpParsingOptions) config formatContext =
     async {
@@ -402,25 +402,13 @@ let format (checker: FSharpChecker) (parsingOptions: FSharpParsingOptions) confi
         return merged
     }
 
-let addNewlineIfNeeded (formattedSourceCode: string) =
-    // When formatting the whole document, an EOL is required
-    if formattedSourceCode.EndsWith(Environment.NewLine)
-    then formattedSourceCode
-    else formattedSourceCode + Environment.NewLine
-
 /// Format a source string using given config
 let formatDocument (checker: FSharpChecker) (parsingOptions: FSharpParsingOptions) config formatContext =
-    async {
-        let! formattedSourceCode = format checker parsingOptions config formatContext
-        return addNewlineIfNeeded formattedSourceCode
-    }
+    format checker parsingOptions config formatContext
 
 /// Format an abstract syntax tree using given config
 let formatAST ast defines formatContext config =
-    let formattedSourceCode =
-        formatWith ast defines [] formatContext config
-
-    addNewlineIfNeeded formattedSourceCode
+    formatWith ast defines [] formatContext config
 
 /// Make a range from (startLine, startCol) to (endLine, endCol) to select some text
 let makeRange fileName startLine startCol endLine endCol =

--- a/src/Fantomas/CodePrinter.fs
+++ b/src/Fantomas/CodePrinter.fs
@@ -76,10 +76,11 @@ let addSpaceBeforeParensInFunDef (astContext: ASTContext) (functionOrMethod: str
     | (_: string), _ -> not isLastPartUppercase
     | _ -> true
 
-let rec genParsedInput astContext =
-    function
+let rec genParsedInput astContext ast =
+    match ast with
     | ImplFile im -> genImpFile astContext im
     | SigFile si -> genSigFile astContext si
+    +> ifElseCtx lastWriteEventIsNewline sepNone sepNln
 
 (*
     See https://github.com/fsharp/FSharp.Compiler.Service/blob/master/src/fsharp/ast.fs#L1518

--- a/src/Fantomas/Context.fs
+++ b/src/Fantomas/Context.fs
@@ -276,13 +276,18 @@ let internal dump (ctx: Context) =
 
     ctx.WriterModel.Lines
     |> List.rev
-    |> String.concat Environment.NewLine
+    |> List.skipWhile ((=) "")
+    |> List.map (fun line -> line.TrimEnd())
+    |> String.concat ctx.Config.EndOfLine.NewLineString
 
 let internal dumpAndContinue (ctx: Context) =
 #if DEBUG
     let m = finalizeWriterModel ctx
     let lines = m.WriterModel.Lines |> List.rev
-    let code = String.concat Environment.NewLine lines
+
+    let code =
+        String.concat ctx.Config.EndOfLine.NewLineString lines
+
     printfn "%s" code
 #endif
     ctx

--- a/src/Fantomas/Fantomas.fsproj
+++ b/src/Fantomas/Fantomas.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.3.0-alpha-004</Version>
+    <Version>4.3.0-alpha-005</Version>
     <Description>Source code formatter for F#</Description>
     <WarningsAsErrors>FS0025</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Fantomas/FormatConfig.fs
+++ b/src/Fantomas/FormatConfig.fs
@@ -24,6 +24,36 @@ type MultilineFormatterType =
         | "number_of_items" -> Some(box MultilineFormatterType.NumberOfItems)
         | _ -> None
 
+[<RequireQualifiedAccess>]
+type EndOfLineStyle =
+    | LF
+    | CR
+    | CRLF
+    member x.NewLineString =
+        match x with
+        | LF -> "\n"
+        | CR -> "\r"
+        | CRLF -> "\r\n"
+
+    static member FromEnvironment =
+        match Environment.NewLine with
+        | "\n" -> LF
+        | "\r\n" -> CRLF
+        | other -> failwithf "Unknown system newline string found: %s" other
+
+    static member ToConfigString(eol: EndOfLineStyle) =
+        match eol with
+        | EndOfLineStyle.LF -> "lf"
+        | EndOfLineStyle.CR -> "cr"
+        | EndOfLineStyle.CRLF -> "crlf"
+
+    static member OfConfigString(eolString: string) =
+        match eolString with
+        | "lf" -> Some(EndOfLineStyle.LF)
+        | "cr" -> failwith "Carriage returns are not valid for F# code, please use one of 'lf' or 'crlf'"
+        | "crlf" -> Some(EndOfLineStyle.CRLF)
+        | _ -> None
+
 // NOTE: try to keep this list below in sync with the docs (e.g. Documentation.md)
 type FormatConfig =
     { /// Number of spaces for each indentation
@@ -61,6 +91,7 @@ type FormatConfig =
       AlignFunctionSignatureToIndentation: bool
       AlternativeLongMemberDefinitions: bool
       DisableElmishSyntax: bool
+      EndOfLine: EndOfLineStyle
       /// Pretty printing based on ASTs only
       StrictMode: bool }
 
@@ -98,4 +129,5 @@ type FormatConfig =
           AlignFunctionSignatureToIndentation = false
           AlternativeLongMemberDefinitions = false
           DisableElmishSyntax = false
+          EndOfLine = EndOfLineStyle.FromEnvironment
           StrictMode = false }

--- a/src/Fantomas/Utils.fs
+++ b/src/Fantomas/Utils.fs
@@ -25,12 +25,6 @@ module String =
     let startsWithOrdinal (prefix: string) (str: string) =
         str.StartsWith(prefix, StringComparison.Ordinal)
 
-    let removeTrailingSpaces (source: string) =
-        source.Split([| Environment.NewLine |], StringSplitOptions.None)
-        |> Array.map (fun line -> line.TrimEnd())
-        |> fun lines -> String.Join(Environment.NewLine, lines)
-        |> fun code -> code.TrimStart(Environment.NewLine.ToCharArray())
-
     let private lengthWithoutSpaces (str: string) =
         normalizeNewLine str
         |> fun s ->


### PR DESCRIPTION
* parse end_of_line values into the config

* use the user-provided end of lines for newline insertion

* Add last newline as WriteEvent in CodePrinter.fs.
Trim lines inside Context.dump function.

* Fail when user provides cr as end_of_line value.

* Working implementation.

* Remove ignored test.

* Remove unintended newline.

* Add release notes for 4.3.0-alpha-005.

* Change to actions/setup-dotnet@v1

Co-authored-by: nojaf <florian.verdonck@outlook.com>